### PR TITLE
fix id being undefined issue

### DIFF
--- a/app/screens/Post.js
+++ b/app/screens/Post.js
@@ -55,9 +55,10 @@ class Post extends Component {
   }
 
   async componentDidMount() {
-    let item = await getPostByIdAsync(this.props.navigation.state.params.postID);
+    const { postID } = this.props.navigation.state.params;
+    let item = await getPostByIdAsync();
     this.setState({ item });
-    Amplitude.logEvent(STRINGS.ARTICLE_FULL_LOADED, { ArticleId: id })
+    Amplitude.logEvent(STRINGS.ARTICLE_FULL_LOADED, { ArticleId: postID })
   }
 
   createMarkup(text) {


### PR DESCRIPTION
## Reasons for making this change

Otherwise, a warning showed up in expo because `id` is undefined. This also fixes analytics for post views.