### PR TITLE
Fix validateConfig function

### DIFF
--- a/App.js
+++ b/App.js
@@ -61,7 +61,7 @@ export default function App() {
   const [seen, setSeen] = useState(new Set())
 
   function validateConfig(config) {
-    return Object.keys(config).every(key => key !== undefined && key !== "" && key !== null)
+    return Object.values(config).every(value => value !== undefined && value !== "" && value !== null)
   }
 
   const [validConfig, setValidConfig] = useState(validateConfig(firebaseConfig))


### PR DESCRIPTION
## Reasons for making this change

I think the function `validateConfig` should check if the variable `firebaseConfig` contains all the defined values (apiKey, appId, ...). However, the function was not checking the values, but the object keys, returning `true` every time.

As I did not have the .env file, I got the following error below. After changing the function, the error was resolved.

![image](https://user-images.githubusercontent.com/25728217/219845879-1cba61e8-cac7-41aa-ac55-a626ecfd6252.png)
