### PR TITLE
Fix wildcard without image

### DIFF
--- a/components/Wildcard.js
+++ b/components/Wildcard.js
@@ -17,7 +17,7 @@ const Header = (props) => (
             <Text style={styles.header} category="h6">{props.title}</Text>
             {props.verbose && (<Text category="p2" style={styles.date}>{formatDate(new Date(props.date))}</Text>)}
         </View>
-        <Image source={{ uri: `${props.uri}?w=${width*pixelRatio}` }} style={{ flex: 1, height: 192 }} />
+        { props.uri ? <Image source={{ uri: `${props.uri}?w=${width*pixelRatio}` }} style={{ flex: 1, height: 192 }} /> : null }
     </React.Fragment>
 )
 

--- a/screens/Post.js
+++ b/screens/Post.js
@@ -30,6 +30,7 @@ if (Platform.OS === "android" && UIManager.setLayoutAnimationEnabledExperimental
 
 export default function Post({ route, navigation }) {
     const { article, sourceName } = route.params
+    const articleImage = article["jetpack_featured_media_url"]
     const featuredMedia = `${article["jetpack_featured_media_url"]}?w=${pixelRatio*width}`
     const colorScheme = useColorScheme()
     const theme = useTheme()
@@ -98,10 +99,14 @@ export default function Post({ route, navigation }) {
       // That would vastly increase loading time when so many posts are being fetched at once,
       // most of which are not going to be tapped on anyway.
 
-      Model.media().id(article["featured_media"]).get().then(media => {
-        setCaption(decode(media.caption?.rendered).slice(3, -5))
+      if(article["featuredMedia"]) {
+        Model.media().id(article["featured_media"]).get().then(media => {
+          setCaption(decode(media.caption?.rendered).slice(3, -5))
+          LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut)
+        })
+      } else {
         LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut)
-      })
+      }
     }, [article])
 
 
@@ -109,7 +114,7 @@ export default function Post({ route, navigation }) {
       <React.Fragment>
         <StatusBar style={statusBarStyle} />
         <ImageHeaderScrollView
-          headerImage={{ uri: featuredMedia }}
+          headerImage={articleImage ? { uri: featuredMedia } : ''}
           renderForeground={Foreground}
           maxOverlayOpacity={0.75}
           minOverlayOpacity={0.6}


### PR DESCRIPTION
## Reasons for making this change

Wildcards without an image showed an empty card. When clicking on the article, the app displayed an error for not checking if the article had an image.

## Screenshots

Before

![image](https://user-images.githubusercontent.com/25728217/219851761-23b41ec6-49b5-4397-bdc9-d6be6fe6828a.png)

After

![image](https://user-images.githubusercontent.com/25728217/219851766-dc653622-4428-4d97-b39d-e17267d05f12.png)

Error (Solved)

![image](https://user-images.githubusercontent.com/25728217/219851775-60ffccd7-f929-4cbc-9396-a7ae6617f002.png)

